### PR TITLE
#18 Include path exceptions at end of cp

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ Optionally, the configuration can be modified with:
 - `outputFile` File to redirect the process output
 - `options`: A list of VM options passed to the executable.
 - `commandlineArgs`: Arguments separated by space for the executed program
+- `includePathExceptionsInClasspath`: When resolving the module-path, setting this value to true will include the 
+dependencies that generate path exceptions in the classpath. By default the value is false, and these dependencies 
+won't be included.
 
 For instance, the following configuration adds some VM options and a command line argument:
 


### PR DESCRIPTION
I necessarily need to depend on some modules that have classes in the default java package. Such modules cause exceptions during path resolution, when javafx-maven-plugin sorts out the modulepath and classpath. Here we include such path exceptions at the tail of the generated classpath.