### PR TITLE
Snapshot artifacts should be released if version tag contains SNAPSHOT

### DIFF
--- a/.ci/deploy-snapshot.sh
+++ b/.ci/deploy-snapshot.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
 
 # Find version
-ver=$(grep -m1 '<version>' pom.xml)
-ver=${ver%<*};
-ver=${ver#*>};
+ver=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
 
 # deploy if snapshot found
 if [[ $ver == *"SNAPSHOT"* ]] 
 then
     cp .travis.settings.xml $HOME/.m2/settings.xml
     mvn deploy -DskipTests=true -Dgpg.skip
-fi 
+fi

--- a/.ci/snapshot.sh
+++ b/.ci/snapshot.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Find version
+ver=$(grep -m1 '<version>' pom.xml)
+ver=${ver%<*};
+ver=${ver#*>};
+
+# deploy if snapshot found
+if [[ $ver == *"SNAPSHOT"* ]] 
+then
+    cp .travis.settings.xml $HOME/.m2/settings.xml
+    mvn deploy -DskipTests=true -Dgpg.skip
+fi 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ cache:
 deploy:
   # Deploy snapshots on every commit made to master
   - provider: script
-    script: sh .ci/snapshot.sh
+    script: sh .ci/deploy-snapshot.sh
     skip_cleanup: true
     on:
       branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ cache:
 deploy:
   # Deploy snapshots on every commit made to master
   - provider: script
-    script: "cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy -DskipTests=true -Dgpg.skip"
+    script: sh .ci/snapshot.sh
     skip_cleanup: true
     on:
       branch: master


### PR DESCRIPTION
Instead of directly calling `mvn deploy`, we navigate through a script which checks if version tag in pom.xml contains SNAPSHOT.