### PR TITLE
Add jlink 13 new option --strip-java-debug-attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ all the required jars needs to be added as a separate dependency, like:
 The same command line options for `jlink` can be set:
 
 - `stripDebug`: Strips debug information out. Values: false (default) or true
+- `stripJavaDebugAttributes`: Strip Java debug attributes out (since Java 13), Values: false (default) or true
 - `compress`: Compression level of the resources being used. Values: 0 (default), 1, 2. 
 - `noHeaderFiles`: Removes the `includes` directory in the resulting runtime image. Values: false (default) or true
 - `noManPages`: Removes the `man` directory in the resulting runtime image. Values: false (default) or true

--- a/src/main/java/org/openjfx/JavaFXJLinkMojo.java
+++ b/src/main/java/org/openjfx/JavaFXJLinkMojo.java
@@ -56,6 +56,13 @@ public class JavaFXJLinkMojo extends JavaFXBaseMojo {
     private boolean stripDebug;
 
     /**
+     * Strip Java debug attributes out, equivalent to <code>--strip-java-debug-attributes</code>,
+     * default false
+     */
+    @Parameter(property = "javafx.stripJavaDebugAttributes", defaultValue = "false")
+    private boolean stripJavaDebugAttributes;
+
+    /**
      * Compression level of the resources being used, equivalent to:
      * <code>-c, --compress=level</code>. Valid values: <code>0, 1, 2</code>,
      * default 2
@@ -283,6 +290,9 @@ public class JavaFXJLinkMojo extends JavaFXBaseMojo {
 
         if (stripDebug) {
             commandArguments.add(" --strip-debug");
+        }
+        if (stripJavaDebugAttributes) {
+            commandArguments.add(" --strip-java-debug-attributes");
         }
         if (bindServices) {
             commandArguments.add(" --bind-services");

--- a/src/main/java/org/openjfx/JavaFXJLinkMojo.java
+++ b/src/main/java/org/openjfx/JavaFXJLinkMojo.java
@@ -44,10 +44,13 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Mojo(name = "jlink", requiresDependencyResolution = ResolutionScope.RUNTIME)
 public class JavaFXJLinkMojo extends JavaFXBaseMojo {
+
+    private static final Pattern JLINK_VERSION_PATTERN = Pattern.compile("(1[3-9]|[2-9][0-9]|\\d{3,})");
 
     /**
      * Strips debug information out, equivalent to <code>-G, --strip-debug</code>,
@@ -373,7 +376,7 @@ public class JavaFXJLinkMojo extends JavaFXBaseMojo {
         }
 
         String versionStr = new String(baos.toByteArray());
-        return versionStr.matches("1[3-9][.\\s]*");
+        return JLINK_VERSION_PATTERN.matcher(versionStr).lookingAt();
     }
 
     // for tests


### PR DESCRIPTION
[From Java 13 JLink has a new option, `--strip-java-debug-attributes`][openjdk-8219207], which so far is like `--strip-debug`.

From this version in Linux  `--strip-debug` need `objcopy` which is part of `binutils` and there are at least two Docker-related reported bugs ([AdoptOpenJDK/openjdk-docker #260][bug-260] and [docker-library/openjdk #351][bug-351]) because of this. The same problem is present in my WSL installation (Ubuntu 18.04).

With this PR users can avoid this problems by using `stripJavaDebugAttributes` option instead `stripDebug` in the plugin configuration.


[openjdk-8219207]: https://bugs.openjdk.java.net/browse/JDK-8219207
[bug-260]: https://github.com/AdoptOpenJDK/openjdk-docker/issues/260
[bug-351]: https://github.com/docker-library/openjdk/issues/351