### PR TITLE
#63 Add sdk extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,14 @@ For instance, the following configuration adds some VM options and a command lin
 </plugin>
 ```
 
-**Note**
+**Local SDK**
 
-It is possible to use a local SDK instead of Maven Central. 
+It is possible to use a local SDK instead of Maven Central artifacts. 
 This is helpful for developers trying to test a local build of OpenJFX. 
-Since transitive dependencies are not resolved, 
-all the required jars needs to be added as a separate dependency, like:
+
+One way to do it is using local dependencies. However, 
+since transitive dependencies are not resolved, 
+all the required jars need to be added as a separate dependency.
 
 ```
 <properties>
@@ -171,6 +173,30 @@ all the required jars needs to be added as a separate dependency, like:
     ...
 </dependencies>
 ```
+
+Alternatively, while keeping the regular JavaFX dependencies, 
+the path to a local JavaFX SDK can be set:
+ 
+```
+<dependencies>
+    <dependency>
+        <groupId>org.openjfx</groupId>
+        <artifactId>javafx-controls</artifactId>
+        <version>${javafx.version}</version>
+    </dependency>
+    ...
+</dependencies>
+
+<plugin>
+    <groupId>org.openjfx</groupId>
+    <artifactId>javafx-maven-plugin</artifactId>
+    <version>${javafx.plugin.version}</version>
+    <configuration>
+        <sdk>/path/to/javafx-sdk</sdk>
+...
+``` 
+ 
+and all the JavaFX dependencies (including transitive ones) will be replaced.
 
 ### javafx:jlink options
 


### PR DESCRIPTION
This PR fixes #63 adding an `sdk` extension, similar to the JavaFX Gradle plugin one, that is used to override the JavaFX artifacts that will be selected, instead of using the existing Maven mechanism (with `systemPath`), which is still valid.