### PR TITLE
#68 Automatically compile project before execute javafx:jlink goal, if needed

### DIFF
--- a/src/main/java/org/openjfx/JavaFXBaseMojo.java
+++ b/src/main/java/org/openjfx/JavaFXBaseMojo.java
@@ -177,20 +177,7 @@ abstract class JavaFXBaseMojo extends AbstractMojo {
         }
 
         String outputDirectory = project.getBuild().getOutputDirectory();
-        if (outputDirectory == null || outputDirectory.isEmpty()) {
-            throw new MojoExecutionException("Output directory doesn't exist, compile first");
-        }
-
         File[] classes = new File(outputDirectory).listFiles();
-        if (classes == null || classes.length == 0) {
-            getLog().debug("Output directory was empty, compiling...");
-            classes = new File(outputDirectory).listFiles();
-            if (classes == null || classes.length == 0) {
-                throw new MojoExecutionException("Output directory is empty, compile first");
-            }
-        } else {
-            // TODO: verify if classes require compiling
-        }
 
         File moduleDescriptorPath = Stream
                 .of(classes)

--- a/src/main/java/org/openjfx/JavaFXBaseMojo.java
+++ b/src/main/java/org/openjfx/JavaFXBaseMojo.java
@@ -177,7 +177,14 @@ abstract class JavaFXBaseMojo extends AbstractMojo {
         }
 
         String outputDirectory = project.getBuild().getOutputDirectory();
+        if (outputDirectory == null || outputDirectory.isEmpty()) {
+            throw new MojoExecutionException("Error: Output directory doesn't exist");
+        }
+
         File[] classes = new File(outputDirectory).listFiles();
+        if (classes == null || classes.length == 0) {
+            throw new MojoExecutionException("Error: Output directory is empty");
+        }
 
         File moduleDescriptorPath = Stream
                 .of(classes)

--- a/src/main/java/org/openjfx/JavaFXJLinkMojo.java
+++ b/src/main/java/org/openjfx/JavaFXJLinkMojo.java
@@ -23,6 +23,8 @@ import org.apache.commons.exec.Executor;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -46,6 +48,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Mojo(name = "jlink", requiresDependencyResolution = ResolutionScope.RUNTIME)
+@Execute(phase = LifecyclePhase.PROCESS_CLASSES)
 public class JavaFXJLinkMojo extends JavaFXBaseMojo {
 
     /**


### PR DESCRIPTION
Compilation is carried out through the Maven compile phase instead the goal compiler:compile. Because of this, any goal associated with said phase will also be executed.

Fixes #68 