### PR TITLE
#70 Set default value for javafx:jlink --compress to 0

### DIFF
--- a/src/main/java/org/openjfx/JavaFXJLinkMojo.java
+++ b/src/main/java/org/openjfx/JavaFXJLinkMojo.java
@@ -58,9 +58,9 @@ public class JavaFXJLinkMojo extends JavaFXBaseMojo {
     /**
      * Compression level of the resources being used, equivalent to:
      * <code>-c, --compress=level</code>. Valid values: <code>0, 1, 2</code>,
-     * default 2
+     * default 0
      */
-    @Parameter(property = "javafx.compress", defaultValue = "2")
+    @Parameter(property = "javafx.compress", defaultValue = "0")
     private Integer compress;
 
     /**


### PR DESCRIPTION
Following is the text from https://bugs.openjdk.java.net/browse/JDK-8157991 which explains the difference:

> --compress=0 drops the size of lib/modules by ~30% (106M -> 69.5M), and actually seems to benefit startup in simple tests (~8 ms improvement on Hello World).
--compress=1 drops the size of lib/modules by ~54% (106M -> 49M), but comes with a penalty to startup (~8ms slowdown on Hello World)
--compress=2 drops the size of lib/modules by ~53% (106M -> 49.5M), but comes with an even greater penalty to startup (~13ms slowdown on Hello World) 

Fixes #70 