### PR TITLE
#66 Fix NPE when JAVA_HOME value is in double quotes

### DIFF
--- a/src/main/java/org/openjfx/JavaFXBaseMojo.java
+++ b/src/main/java/org/openjfx/JavaFXBaseMojo.java
@@ -464,7 +464,15 @@ abstract class JavaFXBaseMojo extends AbstractMojo {
     }
 
     private String getJavaHomeEnv(Map<String, String> enviro) {
-        return enviro.get("JAVA_HOME");
+        String javahome = enviro.get("JAVA_HOME");
+        if (javahome == null || javahome.isEmpty()) {
+            return null;
+        }
+
+        int pathStartIndex = javahome.charAt(0) == '"' ? 1 : 0;
+        int pathEndIndex = javahome.charAt(javahome.length() - 1) == '"' ? javahome.length() - 1 : javahome.length();
+
+        return javahome.substring(pathStartIndex, pathEndIndex);
     }
 
     private int executeCommandLine(Executor exec, final CommandLine commandLine, Map<String, String> enviro,


### PR DESCRIPTION
This fixes #66 by removing trailing and leading double quotes, if exist, from JAVA_HOME.

Only happens in Windows since Linux does not allow defining the value of an environment variable in quotes (these are removed by the OS)

**Windows**
```
> set JAVA_HOME="C:\PROGRA~1\Java\adoptopenjdk-13+33_hotspot"
> echo %JAVA_HOME%
"C:\PROGRA~1\Java\adoptopenjdk-13+33_hotspot"
```

**Linux**
```
$ export JAVA_JOME="/usr/local/java/adoptopenjdk-13+33_hotspot"
$ exho $JAVA_HOME
/usr/local/java/adoptopenjdk-13+33_hotspot

$ export JAVA_JOME='/usr/local/java/adoptopenjdk-13+33_hotspot'
$ exho $JAVA_HOME
/usr/local/java/adoptopenjdk-13+33_hotspot
```

Single quotes have not been removed because in Linux it are treated like double quotes and in windows define a path between them is wrong (even any maven command fails).