### PR TITLE
#75 Split <option> value by spaces for javafx:run

### DIFF
--- a/src/main/java/org/openjfx/JavaFXRunMojo.java
+++ b/src/main/java/org/openjfx/JavaFXRunMojo.java
@@ -38,6 +38,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Mojo(name = "run", requiresDependencyResolution = ResolutionScope.RUNTIME)
@@ -128,8 +129,7 @@ public class JavaFXRunMojo extends JavaFXBaseMojo {
                     .filter(Objects::nonNull)
                     .filter(String.class::isInstance)
                     .map(String.class::cast)
-                    .map(s -> s.split(" "))
-                    .map(List::of)
+                    .map(this::splitComplexArgumentString)
                     .flatMap(Collection::stream)
                     .forEach(commandArguments::add);
         }
@@ -181,6 +181,42 @@ public class JavaFXRunMojo extends JavaFXBaseMojo {
             commandArguments.add(commandlineArgs);
         }
         return commandArguments;
+    }
+
+    private List<String> splitComplexArgumentString(String argumentString) {
+        char[] strArr = argumentString.trim().toCharArray();
+
+        List<String> splitedArgs = new ArrayList<>();
+        StringBuilder sb = new StringBuilder();
+
+        char expectedSeparator = ' ';
+        for (int i = 0; i < strArr.length; i++) {
+            char item = strArr[i];
+
+            if (item == expectedSeparator
+                    || (expectedSeparator == ' ' && Pattern.matches("\\s", String.valueOf(item))) ) {
+
+                if (expectedSeparator == '"' || expectedSeparator == '\'') {
+                    sb.append(item);
+                    expectedSeparator = ' ';
+                } else if (expectedSeparator == ' ' && sb.length() > 0) {
+                    splitedArgs.add(sb.toString());
+                    sb.delete(0, sb.length());
+                }
+            } else {
+                if (expectedSeparator == ' ' && (item == '"' || item == '\'')) {
+                    expectedSeparator = item;
+                }
+
+                sb.append(item);
+            }
+
+            if (i == strArr.length - 1 && sb.length() > 0) {
+                splitedArgs.add(sb.toString());
+            }
+        }
+
+        return splitedArgs;
     }
 
     // for tests

--- a/src/main/java/org/openjfx/JavaFXRunMojo.java
+++ b/src/main/java/org/openjfx/JavaFXRunMojo.java
@@ -34,6 +34,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -127,6 +128,9 @@ public class JavaFXRunMojo extends JavaFXBaseMojo {
                     .filter(Objects::nonNull)
                     .filter(String.class::isInstance)
                     .map(String.class::cast)
+                    .map(s -> s.split(" "))
+                    .map(List::of)
+                    .flatMap(Collection::stream)
                     .forEach(commandArguments::add);
         }
         if (!oldJDK) {

--- a/src/main/java/org/openjfx/JavaFXRunMojo.java
+++ b/src/main/java/org/openjfx/JavaFXRunMojo.java
@@ -232,4 +232,8 @@ public class JavaFXRunMojo extends JavaFXBaseMojo {
     void setCommandlineArgs(String commandlineArgs) {
         this.commandlineArgs = commandlineArgs;
     }
+
+    List<String> splitComplexArgumentStringAdapter(String vmOptions) {
+        return splitComplexArgumentString(vmOptions);
+    }
 }

--- a/src/test/java/org/openjfx/JavaFXRunMojoTestCase.java
+++ b/src/test/java/org/openjfx/JavaFXRunMojoTestCase.java
@@ -206,4 +206,34 @@ public class JavaFXRunMojoTestCase extends AbstractMojoTestCase {
         }
         return result;
     }
+
+    public void testSplitComplexArgumentString() {
+        String option = "param1 " +
+                "param2   \n   " +
+                "param3\n" +
+                "param4=\"/path/to/my file.log\"   " +
+                "'var\"foo   var\"foo' " +
+                "'var\"foo'   " +
+                "'var\"foo' " +
+                "\"foo'var foo'var\" " +
+                "\"foo'var\" " +
+                "\"foo'var\"";
+
+        String expected = "START," +
+                "param1," +
+                "param2," +
+                "param3," +
+                "param4=\"/path/to/my file.log\"," +
+                "'var\"foo   var\"foo'," +
+                "'var\"foo'," +
+                "'var\"foo'," +
+                "\"foo'var foo'var\"," +
+                "\"foo'var\"," +
+                "\"foo'var\"";
+
+        String splitedOption = new JavaFXRunMojo().splitComplexArgumentStringAdapter(option)
+                .stream().reduce("START", (s1, s2) -> s1 + "," + s2);
+
+        assertEquals(expected, splitedOption);
+    }
 }


### PR DESCRIPTION
When `javafx:jlink` command creates the luncher all <option> values are joined using an space like separator, because of this the luncher pass VM args in the right way. In the other hand for the command `javafx:run` the values of <option> are used as they are defined, but if this values contain spaces there are not handle well and the VM does not receive them correctly.

It is desirable that the behavior of both commands, regarding the treatment of the VM args, be the same.

This PR fix #75.