### PR TITLE
Clarify documentation for javafx:run

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ The following configuration adds some VM options, and a command line argument:
 </plugin>
 ```
 
+so it can be processed by the main method like:
+
+```java
+public static void main(String[] args) {
+    if (args.length > 0 && "foo".equals(args[0])) {
+        // do something
+    }
+    launch();
+}
+```
+
 **Note**
 
 It is possible to use a local SDK instead of Maven Central. 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The following configuration adds some VM options, and a command line argument:
             <option>--add-opens</option>
             <option>java.base/java.lang=org.openjfx.hellofx</option>
         </options>
-        <commandlineArgs>-Xmx1024m</commandlineArgs>
+        <commandlineArgs>foo</commandlineArgs>
     </configuration>
 </plugin>
 ```


### PR DESCRIPTION
-Xmx1024m is a valid VM option,
so it shouldn't be used as an example of a program argument