### PR TITLE
Split commandlineArgs option when using javafx:run

### DIFF
--- a/src/main/java/org/openjfx/JavaFXRunMojo.java
+++ b/src/main/java/org/openjfx/JavaFXRunMojo.java
@@ -179,7 +179,8 @@ public class JavaFXRunMojo extends JavaFXBaseMojo {
         }
 
         if (commandlineArgs != null) {
-            commandArguments.add(commandlineArgs);
+            splitComplexArgumentString(commandlineArgs)
+                    .forEach(commandArguments::add);
         }
         return commandArguments;
     }
@@ -234,7 +235,7 @@ public class JavaFXRunMojo extends JavaFXBaseMojo {
         this.commandlineArgs = commandlineArgs;
     }
 
-    List<String> splitComplexArgumentStringAdapter(String vmOptions) {
-        return splitComplexArgumentString(vmOptions);
+    List<String> splitComplexArgumentStringAdapter(String cliOptions) {
+        return splitComplexArgumentString(cliOptions);
     }
 }


### PR DESCRIPTION
This PR fix #102 using the same approach as #76.