### PR TITLE
Overload javafx:run goal to work with JavaFX 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
       <artifactId>commons-exec</artifactId>
       <version>1.3</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-invoker</artifactId>
+      <version>2.2</version>
+    </dependency>
 
     <!--test-->
     <dependency>
@@ -139,8 +144,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>
-          <source>${maven.compiler.source}</source>
-          <target>${maven.compiler.target}</target>
+          <source>9</source>
+          <target>9</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -144,8 +144,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>
-          <source>9</source>
-          <target>9</target>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/org/openjfx/JavaFXRunFixMojo.java
+++ b/src/main/java/org/openjfx/JavaFXRunFixMojo.java
@@ -55,6 +55,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * A temporary mojo introduced to run JavaFX applications
+ * with Java 17 Maven artifacts.
+ */
 @Mojo(name = "run", requiresDependencyResolution = ResolutionScope.COMPILE)
 @Execute(phase = LifecyclePhase.PROCESS_RESOURCES)
 public class JavaFXRunFixMojo extends JavaFXBaseMojo {

--- a/src/main/java/org/openjfx/JavaFXRunFixMojo.java
+++ b/src/main/java/org/openjfx/JavaFXRunFixMojo.java
@@ -57,7 +57,7 @@ import java.util.stream.Collectors;
 
 @Mojo(name = "run", requiresDependencyResolution = ResolutionScope.COMPILE)
 @Execute(phase = LifecyclePhase.PROCESS_RESOURCES)
-public class JavaFXRunMojoFix extends JavaFXBaseMojo {
+public class JavaFXRunFixMojo extends JavaFXBaseMojo {
 
     @Parameter(readonly = true, required = true, defaultValue = "${basedir}/pom.xml")
     String pom;

--- a/src/main/java/org/openjfx/JavaFXRunFixMojo.java
+++ b/src/main/java/org/openjfx/JavaFXRunFixMojo.java
@@ -136,6 +136,7 @@ public class JavaFXRunFixMojo extends JavaFXBaseMojo {
 
         invocationRequest.setPomFile(modifiedPomFile);
         invocationRequest.setGoals(Collections.singletonList("javafx:runx"));
+        invocationRequest.setUserSettingsFile(session.getRequest().getUserSettingsFile());
 
         final Invoker invoker = new DefaultInvoker();
         try {

--- a/src/main/java/org/openjfx/JavaFXRunFixMojo.java
+++ b/src/main/java/org/openjfx/JavaFXRunFixMojo.java
@@ -135,7 +135,7 @@ public class JavaFXRunFixMojo extends JavaFXBaseMojo {
         }
 
         invocationRequest.setPomFile(modifiedPomFile);
-        invocationRequest.setGoals(Collections.singletonList("javafx:runx"));
+        invocationRequest.setGoals(Collections.singletonList("javafx:dorun"));
         invocationRequest.setUserSettingsFile(session.getRequest().getUserSettingsFile());
 
         final Invoker invoker = new DefaultInvoker();

--- a/src/main/java/org/openjfx/JavaFXRunFixMojo.java
+++ b/src/main/java/org/openjfx/JavaFXRunFixMojo.java
@@ -62,6 +62,10 @@ public class JavaFXRunFixMojo extends JavaFXBaseMojo {
     @Parameter(readonly = true, required = true, defaultValue = "${basedir}/pom.xml")
     String pom;
 
+    // gluonfx-maven-plugin creates `runPom.xml` for gluonfx:runagent goal
+    @Parameter(readonly = true, required = true, defaultValue = "${basedir}/runPom.xml")
+    String runpom;
+
     @Parameter(readonly = true, required = true, defaultValue = "${project.basedir}/modifiedPom.xml")
     String modifiedPom;
 
@@ -95,7 +99,7 @@ public class JavaFXRunFixMojo extends JavaFXBaseMojo {
 
         // 1. Create modified pom
         File modifiedPomFile = new File(modifiedPom);
-        try (InputStream is = new FileInputStream(pom)) {
+        try (InputStream is = new FileInputStream(new File(runpom).exists() ? runpom : pom)) {
             // 2. Create model from current pom
             Model model = new MavenXpp3Reader().read(is);
 

--- a/src/main/java/org/openjfx/JavaFXRunMojo.java
+++ b/src/main/java/org/openjfx/JavaFXRunMojo.java
@@ -47,10 +47,10 @@ import static org.openjfx.model.RuntimePathOption.MODULEPATH;
 /**
  * Mojo to run a JavaFX application.
  * 
- * Mojo name change from 'run' to 'runx' is temporary. It will be reverted
+ * Mojo name change from 'run' to 'dorun' is temporary. It will be reverted
  * once JavaFX 17.x empty jars are available with Automatic-Module-Name.
  */
-@Mojo(name = "runx", requiresDependencyResolution = ResolutionScope.RUNTIME)
+@Mojo(name = "dorun", requiresDependencyResolution = ResolutionScope.RUNTIME)
 @Execute(phase = LifecyclePhase.PROCESS_CLASSES)
 public class JavaFXRunMojo extends JavaFXBaseMojo {
 

--- a/src/main/java/org/openjfx/JavaFXRunMojo.java
+++ b/src/main/java/org/openjfx/JavaFXRunMojo.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 import static org.openjfx.model.RuntimePathOption.CLASSPATH;
 import static org.openjfx.model.RuntimePathOption.MODULEPATH;
 
-@Mojo(name = "run", requiresDependencyResolution = ResolutionScope.RUNTIME)
+@Mojo(name = "runx", requiresDependencyResolution = ResolutionScope.RUNTIME)
 @Execute(phase = LifecyclePhase.PROCESS_CLASSES)
 public class JavaFXRunMojo extends JavaFXBaseMojo {
 

--- a/src/main/java/org/openjfx/JavaFXRunMojo.java
+++ b/src/main/java/org/openjfx/JavaFXRunMojo.java
@@ -44,6 +44,12 @@ import java.util.stream.Collectors;
 import static org.openjfx.model.RuntimePathOption.CLASSPATH;
 import static org.openjfx.model.RuntimePathOption.MODULEPATH;
 
+/**
+ * Mojo to run a JavaFX application.
+ * 
+ * Mojo name change from 'run' to 'runx' is temporary. It will be reverted
+ * once JavaFX 17.x empty jars are available with Automatic-Module-Name.
+ */
 @Mojo(name = "runx", requiresDependencyResolution = ResolutionScope.RUNTIME)
 @Execute(phase = LifecyclePhase.PROCESS_CLASSES)
 public class JavaFXRunMojo extends JavaFXBaseMojo {

--- a/src/main/java/org/openjfx/JavaFXRunMojoFix.java
+++ b/src/main/java/org/openjfx/JavaFXRunMojoFix.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2021, Gluon
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.openjfx;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Profile;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.*;
+import org.apache.maven.shared.invoker.*;
+import org.openjfx.model.JavaFXDependency;
+import org.openjfx.model.JavaFXModule;
+
+import java.io.*;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Mojo(name = "run", requiresDependencyResolution = ResolutionScope.COMPILE)
+@Execute(phase = LifecyclePhase.PROCESS_RESOURCES)
+public class JavaFXRunMojoFix extends JavaFXBaseMojo {
+
+    @Parameter(readonly = true, required = true, defaultValue = "${basedir}/pom.xml")
+    String pom;
+
+    @Parameter(readonly = true, required = true, defaultValue = "${project.basedir}/modifiedPom.xml")
+    String modifiedPom;
+
+    @Parameter(defaultValue = "${session}", readonly = true)
+    MavenSession session;
+
+    @Parameter(defaultValue = "${javafx.platform}", readonly = true)
+    String javafxPlatform;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        String osName = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+        String classifier = "";
+        if (osName.contains("mac")) {
+            classifier = "mac";
+        } else if (osName.contains("nux")) {
+            classifier = "linux";
+        } else if (osName.contains("windows")) {
+            classifier = "win";
+        } else {
+            throw new MojoExecutionException("Error, os.name " + osName + " not supported");
+        }
+
+        String PLATFORM = javafxPlatform != null ? javafxPlatform : classifier;
+
+        final InvocationRequest invocationRequest = new DefaultInvocationRequest();
+        invocationRequest.setProfiles(project.getActiveProfiles().stream()
+                .map(Profile::getId)
+                .collect(Collectors.toList()));
+        invocationRequest.setProperties(session.getRequest().getUserProperties());
+
+        // 1. Create modified pom
+        File modifiedPomFile = new File(modifiedPom);
+        try (InputStream is = new FileInputStream(new File(pom))) {
+            // 2. Create model from current pom
+            Model model = new MavenXpp3Reader().read(is);
+
+            Set<JavaFXDependency> javaFXDependencies = new HashSet<>();
+            List<Dependency> toRemove = new ArrayList<>();
+            // 3. Check for dependencies
+            for (Dependency p : model.getDependencies()) {
+                if (p.getGroupId().equalsIgnoreCase("org.openjfx")) {
+                    toRemove.add(p);
+                    final Optional<JavaFXModule> javaFXModule = JavaFXModule.fromArtifactName(p.getArtifactId());
+                    javaFXModule.ifPresent(module -> {
+                        javaFXDependencies.add(module.getMavenDependency(PLATFORM, p.getVersion()));
+                        javaFXDependencies.addAll(module.getMavenDependencies(PLATFORM, p.getVersion()));
+                    });
+                }
+            }
+            model.getDependencies().removeAll(toRemove);
+            model.getDependencies().addAll(javaFXDependencies);
+
+            // 4. Serialize new pom
+            try (OutputStream os = new FileOutputStream(modifiedPomFile)) {
+                new MavenXpp3Writer().write(os, model);
+            }
+        } catch (Exception e) {
+            if (modifiedPomFile.exists()) {
+                modifiedPomFile.delete();
+            }
+            throw new MojoExecutionException("Error generating agent pom", e);
+        }
+
+        invocationRequest.setPomFile(modifiedPomFile);
+        invocationRequest.setGoals(Collections.singletonList("javafx:runx"));
+
+        final Invoker invoker = new DefaultInvoker();
+        // 8. Execute:
+        try {
+            final InvocationResult invocationResult = invoker.execute(invocationRequest);
+            if (invocationResult.getExitCode() != 0) {
+                throw new MojoExecutionException("Error, javafx:run failed", invocationResult.getExecutionException());
+            }
+        } catch (MavenInvocationException e) {
+            e.printStackTrace();
+            throw new MojoExecutionException("Error", e);
+        } finally {
+            if (modifiedPomFile.exists()) {
+                modifiedPomFile.delete();
+            }
+        }
+    }
+}
+

--- a/src/main/java/org/openjfx/model/JavaFXDependency.java
+++ b/src/main/java/org/openjfx/model/JavaFXDependency.java
@@ -1,0 +1,34 @@
+package org.openjfx.model;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Exclusion;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class JavaFXDependency extends Dependency {
+
+    public JavaFXDependency(String artifactId, String version) {
+        setArtifactId(artifactId);
+        setVersion(version);
+        setGroupId("org.openjfx");
+        setExclusions(exclusions());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        JavaFXDependency that = (JavaFXDependency) o;
+        return this.getArtifactId().equals(that.getArtifactId());
+    }
+    
+    private List<Exclusion> exclusions() {
+        final Exclusion exclusion = new Exclusion();
+        exclusion.setGroupId("org.openjfx");
+        exclusion.setArtifactId("*");
+        List<Exclusion> exclusions = new ArrayList<>();
+        exclusions.add(exclusion);
+        return exclusions;
+    }
+}

--- a/src/main/java/org/openjfx/model/JavaFXDependency.java
+++ b/src/main/java/org/openjfx/model/JavaFXDependency.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (c) 2021, Gluon
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.openjfx.model;
 
 import org.apache.maven.model.Dependency;

--- a/src/main/java/org/openjfx/model/JavaFXModule.java
+++ b/src/main/java/org/openjfx/model/JavaFXModule.java
@@ -76,7 +76,7 @@ public enum JavaFXModule {
         return dependentModules;
     }
 
-    public List<JavaFXDependency> getMavenDependencies(String platform, String version) {
+    public List<JavaFXDependency> getTransitiveMavenDependencies(String platform, String version) {
         List<JavaFXDependency> mavenDependencies = new ArrayList<>();
         for (JavaFXModule dependentModule : dependentModules) {
             mavenDependencies.add(dependentModule.getMavenDependency(platform, version));

--- a/src/main/java/org/openjfx/model/JavaFXModule.java
+++ b/src/main/java/org/openjfx/model/JavaFXModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Gluon
+ * Copyright (c) 2021, Gluon
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/org/openjfx/model/JavaFXModule.java
+++ b/src/main/java/org/openjfx/model/JavaFXModule.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2018, 2020, Gluon
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjfx.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public enum JavaFXModule {
+
+    BASE,
+    GRAPHICS(BASE),
+    CONTROLS(BASE, GRAPHICS),
+    FXML(BASE, GRAPHICS),
+    MEDIA(BASE, GRAPHICS),
+    SWING(BASE, GRAPHICS),
+    WEB(BASE, CONTROLS, GRAPHICS, MEDIA);
+
+    static final String PREFIX_MODULE = "javafx.";
+    private static final String PREFIX_ARTIFACT = "javafx-";
+
+    private List<JavaFXModule> dependentModules;
+
+    JavaFXModule(JavaFXModule...dependentModules) {
+        this.dependentModules = List.of(dependentModules);
+    }
+
+    public static Optional<JavaFXModule> fromArtifactName(String artifactName) {
+        return Stream.of(JavaFXModule.values())
+                .filter(javaFXModule -> artifactName.equals(javaFXModule.getArtifactName()))
+                .findFirst();
+    }
+
+    public String getModuleName() {
+        return PREFIX_MODULE + name().toLowerCase(Locale.ROOT);
+    }
+
+    public String getModuleJarFileName() {
+        return getModuleName() + ".jar";
+    }
+
+    public String getArtifactName() {
+        return PREFIX_ARTIFACT + name().toLowerCase(Locale.ROOT);
+    }
+
+    public List<JavaFXModule> getDependentModules() {
+        return dependentModules;
+    }
+
+    public List<JavaFXDependency> getMavenDependencies(String platform, String version) {
+        List<JavaFXDependency> mavenDependencies = new ArrayList<>();
+        for (JavaFXModule dependentModule : dependentModules) {
+            mavenDependencies.add(dependentModule.getMavenDependency(platform, version));
+        }
+        return mavenDependencies;
+    }
+
+    public JavaFXDependency getMavenDependency(String platform, String version) {
+        final JavaFXDependency dependency = new JavaFXDependency(getArtifactName(), version);
+        dependency.setVersion(version);
+        dependency.setClassifier(platform);
+        return dependency;
+    }
+}

--- a/src/test/java/org/openjfx/JavaFXRunMojoTestCase.java
+++ b/src/test/java/org/openjfx/JavaFXRunMojoTestCase.java
@@ -56,7 +56,6 @@ import java.util.stream.Collectors;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@Ignore
 public class JavaFXRunMojoTestCase extends AbstractMojoTestCase {
 
     private static final File LOCAL_REPO = new File( "src/test/repository" );
@@ -142,7 +141,7 @@ public class JavaFXRunMojoTestCase extends AbstractMojoTestCase {
     }
 
     protected JavaFXRunMojo getJavaFXRunMojo(File testPom) throws Exception {
-        JavaFXRunMojo mojo = (JavaFXRunMojo) lookupMojo("run", testPom);
+        JavaFXRunMojo mojo = (JavaFXRunMojo) lookupMojo("runx", testPom);
         assertNotNull(mojo);
 
         setUpProject(testPom, mojo);

--- a/src/test/java/org/openjfx/JavaFXRunMojoTestCase.java
+++ b/src/test/java/org/openjfx/JavaFXRunMojoTestCase.java
@@ -41,7 +41,6 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -141,7 +140,7 @@ public class JavaFXRunMojoTestCase extends AbstractMojoTestCase {
     }
 
     protected JavaFXRunMojo getJavaFXRunMojo(File testPom) throws Exception {
-        JavaFXRunMojo mojo = (JavaFXRunMojo) lookupMojo("runx", testPom);
+        JavaFXRunMojo mojo = (JavaFXRunMojo) lookupMojo("dorun", testPom);
         assertNotNull(mojo);
 
         setUpProject(testPom, mojo);

--- a/src/test/java/org/openjfx/JavaFXRunMojoTestCase.java
+++ b/src/test/java/org/openjfx/JavaFXRunMojoTestCase.java
@@ -41,6 +41,7 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -55,6 +56,7 @@ import java.util.stream.Collectors;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Ignore
 public class JavaFXRunMojoTestCase extends AbstractMojoTestCase {
 
     private static final File LOCAL_REPO = new File( "src/test/repository" );


### PR DESCRIPTION
This is a hack to make sure that Maven application don't fail with JavaFX 17. 

Since there is no way to update the dependency list after its creation in MavenProject, we had to resort for the creation of a new Mojo: `JavaFXRunFixMojo` which will be called for `javafx:run`. This new Mojo will then create a new pom.xml which will add classifiers to the JavaFX dependencies and exclude all JavaFX transitive dependencies.

For example, a dependency for `javafx-controls` on `linux`, will be available as the following in the new modified pom:

```
<dependency>
  <groupId>org.openjfx</groupId>
  <artifactId>javafx-controls</artifactId>
  <version>17</version>
  <classifier>linux</classifier>
  <exclusions>
    <exclusion>
      <artifactId>*</artifactId>
      <groupId>org.openjfx</groupId>
    </exclusion>
  </exclusions>
</dependency>
```

We will then call the existing, `JavaFXRunMojo` with this new pom. 

Since 2 Mojo's cannot have the same  name, the name for `JavaFXRunMojo` has been updated to `runx`. 

This has been tested against the following Applications:

Modular
----
* [ChatApp](https://github.com/gluonhq/ChatApp)
* [OpenJFX Modular Sample](https://github.com/openjfx/samples/)

Non-Modular
----
* [Scene Builder](https://github.com/gluonhq/scenebuilder/)
* [OpenJFX Non-Modular Sample](https://github.com/openjfx/samples/)