### PR TITLE
Fix toolchain support for non-java executables

### DIFF
--- a/src/main/java/org/openjfx/JavaFXBaseMojo.java
+++ b/src/main/java/org/openjfx/JavaFXBaseMojo.java
@@ -391,7 +391,7 @@ abstract class JavaFXBaseMojo extends AbstractMojo {
         	Toolchain toolchain = toolchainManager.getToolchainFromBuildContext("jdk", session);
             if (toolchain != null) {
                 getLog().info("Toolchain in javafx-maven-plugin " + toolchain);
-                exec = toolchain.findTool("java");
+                exec = toolchain.findTool(executable);
                 getLog().debug("Tool in toolchain in javafx-maven-plugin " + exec);
             }
         }


### PR DESCRIPTION
https://github.com/openjfx/javafx-maven-plugin/pull/118 introduced toolchain support. However, due to the hard-coded `"java"`, this doesn't work for non-java executables such as jlink (i.e. https://github.com/openjfx/javafx-maven-plugin/issues/148)

Fixes #148