### PR TITLE
Respect includePathExceptionsInClasspath also if no module-info.java is provided

### DIFF
--- a/src/main/java/org/openjfx/JavaFXBaseMojo.java
+++ b/src/main/java/org/openjfx/JavaFXBaseMojo.java
@@ -273,10 +273,6 @@ abstract class JavaFXBaseMojo extends AbstractMojo {
                 resolvePathsResult.getClasspathElements().forEach(file -> classpathElements.add(file.getPath()));
                 resolvePathsResult.getModulepathElements().keySet().forEach(file -> modulepathElements.add(file.getPath()));
 
-                if (includePathExceptionsInClasspath) {
-                    resolvePathsResult.getPathExceptions().keySet()
-                            .forEach(file -> classpathElements.add(file.getPath()));
-                }
             } else {
                 // non-modular projects
                 pathElements.forEach((k, v) -> {
@@ -287,6 +283,11 @@ abstract class JavaFXBaseMojo extends AbstractMojo {
                         classpathElements.add(k);
                     }
                 });
+            }
+
+            if (includePathExceptionsInClasspath) {
+                resolvePathsResult.getPathExceptions().keySet()
+                        .forEach(file -> classpathElements.add(file.getPath()));
             }
         } catch (Exception e) {
             getLog().warn(e.getMessage());

--- a/src/test/java/org/openjfx/JavaFXRunMojoTestCase.java
+++ b/src/test/java/org/openjfx/JavaFXRunMojoTestCase.java
@@ -160,7 +160,7 @@ public class JavaFXRunMojoTestCase extends AbstractMojoTestCase {
         setVariableValueToObject(mojo, "compilePath", project.getCompileClasspathElements());
         setVariableValueToObject(mojo, "session", session);
         setVariableValueToObject(mojo, "executable", "java");
-        setVariableValueToObject(mojo, "basedir", new File(getBasedir(), testPom.getParent()));
+        setVariableValueToObject(mojo, "basedir", testPom.getParentFile());
 
         return mojo;
     }


### PR DESCRIPTION
This PR fixes openjfx/javafx-maven-plugin#62:
- moves the addition of path exceptions to classpath outside of the block that only executes if the JavaFX app contains a `module-info.java`
- fixes a wrong path in unit tests which caused the build to fail under Windows